### PR TITLE
Handle CAPTCHA pages before raising HTTP errors

### DIFF
--- a/gsearch.py
+++ b/gsearch.py
@@ -92,10 +92,18 @@ class GoogleScraper:
                 
                 html = response.text
                 if self._is_captcha_page(html):
-                    raise CaptchaDetectedError(
-                        "Google returned a CAPTCHA challenge; automated access was blocked."
-                    )
-                
+                    attempts += 1
+                    if attempts >= max_attempts:
+                        raise CaptchaDetectedError(
+                            "Google returned a CAPTCHA challenge; automated access was blocked."
+                        )
+
+                    if proxies_arg:
+                        print(f"Proxy {proxy} encountered a CAPTCHA challenge. Retrying...")
+                    else:
+                        print("CAPTCHA challenge detected. Retrying...")
+                    continue
+
                 response.raise_for_status()
                 break # Success
             except CaptchaDetectedError:


### PR DESCRIPTION
## Summary
- inspect Google responses for CAPTCHA markers before raising HTTP errors
- retry proxy rotation on CAPTCHA pages and surface the error after exhausting attempts
- add a regression test covering CAPTCHA detection with HTTP 503 responses

## Testing
- pytest test_gsearch.py::TestGoogleScraper::test_search_captcha_detection_retries_then_raises

------
https://chatgpt.com/codex/tasks/task_e_68da85899a80832ab97c7373e527a2ef